### PR TITLE
Fix cloning fields to match person schema

### DIFF
--- a/client/src/pages/CapTable.tsx
+++ b/client/src/pages/CapTable.tsx
@@ -48,6 +48,14 @@ import type { Person, PersonOnOrg, ShareIssuance, Org } from "@shared/schema";
 
 interface PersonWithRoles extends Person {
   roles: PersonOnOrg[];
+  address?: {
+    line1?: string;
+    line2?: string;
+    city?: string;
+    region?: string;
+    country?: string;
+    postal?: string;
+  };
 }
 
 export default function CapTable() {
@@ -412,14 +420,10 @@ export default function CapTable() {
                       <p className="mt-1">{viewingPerson.email || "Not provided"}</p>
                     </div>
                     <div>
-                      <label className="text-sm font-medium text-muted-foreground">Phone</label>
-                      <p className="mt-1">{viewingPerson.phone || "Not provided"}</p>
-                    </div>
-                    <div>
                       <label className="text-sm font-medium text-muted-foreground">Date of Birth</label>
                       <p className="mt-1">
-                        {viewingPerson.dateOfBirth 
-                          ? formatDate(viewingPerson.dateOfBirth) 
+                        {viewingPerson.dob
+                          ? formatDate(viewingPerson.dob)
                           : "Not provided"
                         }
                       </p>
@@ -462,7 +466,7 @@ export default function CapTable() {
                               </div>
                             )}
                             <div>
-                              <span className="font-medium">Start Date:</span> {formatDate(role.startDate)}
+                              <span className="font-medium">Start Date:</span> {formatDate(role.startAt)}
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- use `dob` and `startAt` when cloning a person
- remove non-existent fields like phone and dateOfBirth from person and cap table views
- pass cloned data into `PersonForm` initial values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bc9302c254832799b408a315face4f