### PR TITLE
feat: add file download routes

### DIFF
--- a/client/src/pages/Documents.tsx
+++ b/client/src/pages/Documents.tsx
@@ -129,6 +129,28 @@ export default function Documents() {
     }
   };
 
+  const handleDownload = async (docId: string, fileKey: string) => {
+    try {
+      const res = await fetch(`/api/docs/${docId}`);
+      if (!res.ok) throw new Error('Failed to download');
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = fileKey.split('/').pop() || 'document';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      toast({
+        title: 'Download failed',
+        description: err instanceof Error ? err.message : 'Unable to download document',
+        variant: 'destructive',
+      });
+    }
+  };
+
   if (!currentEntity) {
     return (
       <div className="flex-1 overflow-auto">
@@ -267,7 +289,12 @@ export default function Documents() {
                           <i className="fas fa-eye mr-2"></i>
                           View
                         </Button>
-                        <Button variant="outline" size="sm" data-testid={`download-doc-${doc.id}`}>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          data-testid={`download-doc-${doc.id}`}
+                          onClick={() => handleDownload(doc.id, doc.fileKey)}
+                        >
                           <i className="fas fa-download mr-2"></i>
                           Download
                         </Button>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -90,6 +90,7 @@ export interface IStorage {
   
   // Generated document operations
   createGeneratedDoc(doc: InsertGeneratedDoc): Promise<GeneratedDoc>;
+  getGeneratedDocById(id: string): Promise<GeneratedDoc | undefined>;
   getGeneratedDocsByOrg(orgId: string): Promise<GeneratedDoc[]>;
   
   // Audit log operations
@@ -336,6 +337,14 @@ export class DatabaseStorage implements IStorage {
   async createGeneratedDoc(doc: InsertGeneratedDoc): Promise<GeneratedDoc> {
     const [created] = await db.insert(generatedDocs).values(doc).returning();
     return created;
+  }
+
+  async getGeneratedDocById(id: string): Promise<GeneratedDoc | undefined> {
+    const [doc] = await db
+      .select()
+      .from(generatedDocs)
+      .where(eq(generatedDocs.id, id));
+    return doc;
   }
 
   async getGeneratedDocsByOrg(orgId: string): Promise<GeneratedDoc[]> {


### PR DESCRIPTION
## Summary
- stream generated documents via GET /api/docs/:docId
- stream minute book files via GET /api/minute-books/:orgId/:fileKey
- add generated doc retrieval helper and hook up frontend download button

## Testing
- `npm run check` *(fails: Property errors in People.tsx and existing route type issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9301f6a883278012827f0d382056