### PR TITLE
refactor: use default document query

### DIFF
--- a/client/src/pages/Documents.tsx
+++ b/client/src/pages/Documents.tsx
@@ -36,8 +36,7 @@ export default function Documents() {
 
   // Fetch documents for current entity
   const { data: documents = [], isLoading } = useQuery<GeneratedDoc[]>({
-    queryKey: ["/api/documents", currentEntity?.id],
-    queryFn: () => fetch(`/api/documents/${currentEntity?.id}`).then(res => res.json()),
+    queryKey: ["/api/orgs", currentEntity?.id, "documents"],
     enabled: !!currentEntity?.id,
   });
 
@@ -50,7 +49,9 @@ export default function Documents() {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/documents"] });
+      queryClient.invalidateQueries({
+        queryKey: ["/api/orgs", currentEntity?.id, "documents"],
+      });
       toast({
         title: "Success",
         description: "Document created successfully",
@@ -74,7 +75,9 @@ export default function Documents() {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/documents"] });
+      queryClient.invalidateQueries({
+        queryKey: ["/api/orgs", currentEntity?.id, "documents"],
+      });
       toast({
         title: "Success",
         description: "New Corporation Bundle created successfully",


### PR DESCRIPTION
## Summary
- fetch documents using the query client's default fetcher
- ensure document mutations invalidate the same query key

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property errors and type mismatches in People.tsx and server/routes.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bc93007dbc8327aecac34d9cdb31b6