### PR TITLE
Allow template file key to be nullable

### DIFF
--- a/migrations/0001_make_templates_file_key_nullable.sql
+++ b/migrations/0001_make_templates_file_key_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "templates" ALTER COLUMN "file_key" DROP NOT NULL;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -130,7 +130,7 @@ export const templates = pgTable("templates", {
   name: text("name").notNull(), // "Bylaw No.1 (CBCA)"
   code: text("code").notNull(), // "BYLAW_CBCA_1"
   scope: text("scope").notNull(), // "organization" | "annual" | "resolution" | "register"
-  fileKey: text("file_key").notNull(), // storage key for .docx
+  fileKey: text("file_key"), // storage key for .docx
   schema: json("schema").notNull(), // required fields map
   ownerId: varchar("owner_id").references(() => users.id),
   createdAt: timestamp("created_at").defaultNow(),


### PR DESCRIPTION
## Summary
- allow template `file_key` to be nullable in schema
- add migration dropping NOT NULL constraint on `templates.file_key`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in client and server)*
- `npm run db:push` *(fails: DATABASE_URL, ensure the database is provisioned)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92ff8ad4832799b564c4b40e4fb6