### PR TITLE
Protect org routes with authentication

### DIFF
--- a/client/src/pages/Documents.tsx
+++ b/client/src/pages/Documents.tsx
@@ -37,7 +37,12 @@ export default function Documents() {
   // Fetch documents for current entity
   const { data: documents = [], isLoading } = useQuery<GeneratedDoc[]>({
     queryKey: ["/api/documents", currentEntity?.id],
-    queryFn: () => fetch(`/api/documents/${currentEntity?.id}`).then(res => res.json()),
+    queryFn: async () => {
+      const res = await fetch(`/api/documents/${currentEntity?.id}`, {
+        credentials: "include",
+      });
+      return await res.json();
+    },
     enabled: !!currentEntity?.id,
   });
 


### PR DESCRIPTION
## Summary
- apply authentication middleware to organization CRUD endpoints
- use authenticated user ID instead of hard-coded placeholder
- ensure document fetches send credentials

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: client/src/pages/People.tsx:573:60 - Property 'address' does not exist on type 'PersonWithRoles'. Did you mean 'addressId'?)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92faea0083279405433017097d23