### PR TITLE
feat: add global audit log endpoint

### DIFF
--- a/client/src/components/TemplateUploader.tsx
+++ b/client/src/components/TemplateUploader.tsx
@@ -130,7 +130,8 @@ export function TemplateUploader({ orgId, onUploadComplete }: TemplateUploaderPr
       queryClient.invalidateQueries({
         queryKey: ["/api/orgs", orgId, "templates"],
       });
-      
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
+
       onUploadComplete?.();
     } catch (error: any) {
       toast({

--- a/client/src/pages/AuditLog.tsx
+++ b/client/src/pages/AuditLog.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 
 export default function AuditLog() {
   const { data: logs = [], isLoading } = useQuery<any[]>({
-    queryKey: ["/api/audit-logs"],
+    queryKey: ["/api", "audit-logs"],
   });
 
   const formatDate = (dateString: string) => {

--- a/client/src/pages/CapTable.tsx
+++ b/client/src/pages/CapTable.tsx
@@ -93,6 +93,7 @@ export default function CapTable() {
       queryClient.invalidateQueries({
         queryKey: ["/api/orgs", currentEntity?.id, "people"],
       });
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
       toast({
         title: "Success",
         description: "Shareholder deleted successfully",
@@ -166,6 +167,7 @@ export default function CapTable() {
                   queryClient.invalidateQueries({
                     queryKey: ["/api/orgs", currentEntity?.id, "people"],
                   });
+                  queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
                 }}
                 onCancel={() => setIsCreateDialogOpen(false)}
               />
@@ -212,6 +214,7 @@ export default function CapTable() {
                       queryClient.invalidateQueries({
                         queryKey: ["/api/orgs", currentEntity?.id, "people"],
                       });
+                      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
                     }}
                     onCancel={() => setIsCreateDialogOpen(false)}
                   />
@@ -493,6 +496,7 @@ export default function CapTable() {
                   queryClient.invalidateQueries({
                     queryKey: ["/api/orgs", currentEntity?.id, "people"],
                   });
+                  queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
                 }}
                 onCancel={() => setEditingPerson(null)}
               />

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -62,7 +62,7 @@ export default function Dashboard() {
   });
 
   const { data: auditLogs = [] } = useQuery<any[]>({
-    queryKey: ["/api/audit-logs"],
+    queryKey: ["/api", "audit-logs"],
     enabled: isAuthenticated && !currentEntity, // Only load when viewing global dashboard
   });
 

--- a/client/src/pages/Documents.tsx
+++ b/client/src/pages/Documents.tsx
@@ -51,6 +51,7 @@ export default function Documents() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/documents"] });
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
       toast({
         title: "Success",
         description: "Document created successfully",
@@ -75,6 +76,7 @@ export default function Documents() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/documents"] });
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
       toast({
         title: "Success",
         description: "New Corporation Bundle created successfully",

--- a/client/src/pages/Entities.tsx
+++ b/client/src/pages/Entities.tsx
@@ -40,6 +40,7 @@ export default function Entities() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/orgs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
       setShowCreateDialog(false);
       toast({
         title: "Success",

--- a/client/src/pages/EntityEdit.tsx
+++ b/client/src/pages/EntityEdit.tsx
@@ -73,6 +73,7 @@ export default function EntityEdit() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/orgs"] });
       queryClient.invalidateQueries({ queryKey: ["/api/orgs", id] });
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
       toast({
         title: "Success",
         description: "Entity updated successfully",

--- a/client/src/pages/People.tsx
+++ b/client/src/pages/People.tsx
@@ -76,6 +76,7 @@ export default function People() {
       queryClient.invalidateQueries({
         queryKey: ["/api/orgs", currentEntity?.id, "people"],
       });
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
       toast({
         title: "Success",
         description: "Person deleted successfully",
@@ -121,6 +122,7 @@ export default function People() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/orgs", currentEntity?.id, "people"] });
+      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
       setIsCreateDialogOpen(false);
       toast({
         title: "Success",
@@ -525,16 +527,17 @@ export default function People() {
                 <PersonForm
                   mode="edit"
                   initialData={viewingPerson}
-                  onSuccess={() => {
-                    setIsEditMode(false);
-                    queryClient.invalidateQueries({
-                      queryKey: ["/api/orgs", currentEntity?.id, "people"],
-                    });
-                    toast({
-                      title: "Success",
-                      description: "Person updated successfully",
-                    });
-                  }}
+                    onSuccess={() => {
+                      setIsEditMode(false);
+                      queryClient.invalidateQueries({
+                        queryKey: ["/api/orgs", currentEntity?.id, "people"],
+                      });
+                      queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
+                      toast({
+                        title: "Success",
+                        description: "Person updated successfully",
+                      });
+                    }}
                   onCancel={() => setIsEditMode(false)}
                   hideButtons={true}
                 />
@@ -647,6 +650,7 @@ export default function People() {
                   queryClient.invalidateQueries({
                     queryKey: ["/api/orgs", currentEntity?.id, "people"],
                   });
+                  queryClient.invalidateQueries({ queryKey: ["/api", "audit-logs"] });
                 }}
                 onCancel={() => setEditingPerson(null)}
               />

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -443,6 +443,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Global audit logs
+  app.get('/api/audit-logs', isAuthenticated, async (req, res) => {
+    try {
+      const logs = await storage.getAuditLogs();
+      res.json(logs);
+    } catch (error) {
+      console.error("Error fetching audit logs:", error);
+      res.status(500).json({ message: "Failed to fetch audit logs" });
+    }
+  });
+
   // Audit logs
   app.get('/api/orgs/:orgId/audit-logs', isAuthenticated, async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -95,6 +95,7 @@ export interface IStorage {
   // Audit log operations
   createAuditLog(log: InsertAuditLog): Promise<AuditLog>;
   getAuditLogsByOrg(orgId: string): Promise<AuditLog[]>;
+  getAuditLogs(): Promise<AuditLog[]>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -357,6 +358,13 @@ export class DatabaseStorage implements IStorage {
       .select()
       .from(auditLogs)
       .where(eq(auditLogs.orgId, orgId))
+      .orderBy(desc(auditLogs.createdAt));
+  }
+
+  async getAuditLogs(): Promise<AuditLog[]> {
+    return await db
+      .select()
+      .from(auditLogs)
       .orderBy(desc(auditLogs.createdAt));
   }
 }


### PR DESCRIPTION
## Summary
- expose global `/api/audit-logs` endpoint backed by new storage method
- use segmented React Query key for audit logs
- refresh audit log queries after entity and document mutations

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68bc92f94c488327addbc75c6239bb1b