### PR TITLE
feat: add person update and delete routes

### DIFF
--- a/client/src/pages/CapTable.tsx
+++ b/client/src/pages/CapTable.tsx
@@ -85,9 +85,10 @@ export default function CapTable() {
   // Delete person mutation
   const deleteMutation = useMutation({
     mutationFn: async (personId: string) => {
-      await apiRequest(`/api/orgs/${currentEntity?.id}/people/${personId}`, {
-        method: "DELETE",
-      });
+      await apiRequest(
+        "DELETE",
+        `/api/orgs/${currentEntity?.id}/people/${personId}`,
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/client/src/pages/People.tsx
+++ b/client/src/pages/People.tsx
@@ -68,9 +68,10 @@ export default function People() {
   // Delete person mutation
   const deleteMutation = useMutation({
     mutationFn: async (personId: string) => {
-      await apiRequest(`/api/orgs/${currentEntity?.id}/people/${personId}`, {
-        method: "DELETE",
-      });
+      await apiRequest(
+        "DELETE",
+        `/api/orgs/${currentEntity?.id}/people/${personId}`,
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary
- add PUT and DELETE routes for managing people in an organization
- implement `deletePerson` with cascading cleanup in storage layer
- update client mutations to call new API endpoints

## Testing
- `npm run check` *(fails: Property 'address' does not exist on type 'PersonWithRoles', etc.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc92f7e79083279bc65ac1011d505d