### PR TITLE
refactor: use method-first apiRequest for deletions

### DIFF
--- a/client/src/pages/CapTable.tsx
+++ b/client/src/pages/CapTable.tsx
@@ -85,9 +85,10 @@ export default function CapTable() {
   // Delete person mutation
   const deleteMutation = useMutation({
     mutationFn: async (personId: string) => {
-      await apiRequest(`/api/orgs/${currentEntity?.id}/people/${personId}`, {
-        method: "DELETE",
-      });
+      await apiRequest(
+        "DELETE",
+        `/api/orgs/${currentEntity?.id}/people/${personId}`
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/client/src/pages/People.tsx
+++ b/client/src/pages/People.tsx
@@ -68,9 +68,10 @@ export default function People() {
   // Delete person mutation
   const deleteMutation = useMutation({
     mutationFn: async (personId: string) => {
-      await apiRequest(`/api/orgs/${currentEntity?.id}/people/${personId}`, {
-        method: "DELETE",
-      });
+      await apiRequest(
+        "DELETE",
+        `/api/orgs/${currentEntity?.id}/people/${personId}`
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary
- call apiRequest with method-first signature when deleting people and shareholders
- keep query invalidation and toast notifications after deletion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc92f566f48327907de3c9d789b4bd